### PR TITLE
Hide order-quantity multiplier beside Subtotal on quotations.

### DIFF
--- a/src/utils/docxGenerator.ts
+++ b/src/utils/docxGenerator.ts
@@ -1133,7 +1133,7 @@ export const generateConfigurationHtml = (
                             </div>
                             ${!isDigitalStandee ? `<div class="quotation-row">
                                 <span class="quotation-label">Subtotal:</span>
-                                <span class="quotation-value" style="font-weight: 700;">₹${formatIndianNumber(subtotal)}${orderQuantity > 1 ? ` (× ${orderQuantity})` : ''}</span>
+                                <span class="quotation-value" style="font-weight: 700;">₹${formatIndianNumber(subtotal)}</span>
                             </div>` : ''}
                             <div class="quotation-row">
                                 <span class="quotation-label">GST</span>

--- a/src/utils/multiProductQuotationHtml.ts
+++ b/src/utils/multiProductQuotationHtml.ts
@@ -154,7 +154,7 @@ const buildProductBox = (item: PdfQuotationLineItem, index: number): string => {
       ${row('Unit Price:', `₹${formatIndianNumber(pricing.unitPrice || 0)}`)}
       ${row(`${areaLabel(item)}:`, areaValue(item))}
       ${row('Quantity (Units):', String(orderQty))}
-      ${!item.isDigitalStandee ? row('Subtotal:', `₹${formatIndianNumber(subtotal)}${orderQty > 1 ? ` (× ${orderQty})` : ''}`) : ''}
+      ${!item.isDigitalStandee ? row('Subtotal:', `₹${formatIndianNumber(subtotal)}`) : ''}
       ${row('GST', GST_RATE)}
       ${row('Product Total:', `₹${formatTotalWithDecimals(productTotal)}`)}
 


### PR DESCRIPTION
Remove the redundant (x N) suffix next to Subtotal so pricing details only show the computed amount.